### PR TITLE
Proactively prevent boot from hanging for 5 minutes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -435,6 +435,16 @@ iface br0 inet static
 allow-hotplug br0:0
 iface br0:0 inet dhcp
 EOT
+
+# apply the fix to prevent the networking from hanging for 5 minutes on boot
+if [ "${ubuntu_version}" == "bionic"];
+then
+  sudo mkdir -p /etc/systemd/system/networking.service.d/
+  sudo bash -c 'echo -e "[Service]\nTimeoutStartSec=5sec" > /etc/systemd/system/networking.service.d/timeout.conf'
+
+  sudo systemctl mask systemd-networkd-wait-online.service
+  sudo systemctl daemon-reload
+fi
 echo -e "\e[32mDone: Configuring Networking\e[0m"
 echo ""
 


### PR DESCRIPTION
Apply the fix from clearpath_iso to prevent the boot from hanging for 5 minutes waiting for networks to become available.  This is a known bug in Ubuntu 18.04, caused by a bad interaction between Network Manager and the bridge configuration, that's aggrivated by the presence of Network Manager's graphical tools.

This fix was requested by the integration team so that we can (hopefully) hand off Jetson customizations to the production team, rather than going through integration.